### PR TITLE
Fix class name is not following convention

### DIFF
--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___InteractorSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___InteractorSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___ModuleTests: QuickSpec {
+final class ___VARIABLE_moduleName___ModuleSpec: QuickSpec {
 
     override func spec() { 
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___PresenterTests: QuickSpec {
+final class ___VARIABLE_moduleName___PresenterSpec: QuickSpec {
 
     override func spec() { 
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___RouterTests: QuickSpec {
+final class ___VARIABLE_moduleName___RouterSpec: QuickSpec {
 
     override func spec() { 
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
@@ -12,14 +12,14 @@ import XCTest
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___ViewControllerTests: QuickSpec {
+final class ___VARIABLE_moduleName___ViewControllerSpec: QuickSpec {
 
     override func spec() { 
 
         var viewController: ___VARIABLE_moduleName___ViewController!
         var output: ___VARIABLE_moduleName___ViewOutputMock!
 
-        describe("a ___VARIABLE_moduleName___ view controller ") { 
+        describe("a ___VARIABLE_moduleName___ view controller") { 
 
             beforeEach { 
                 output = ___VARIABLE_moduleName___ViewOutputMock()

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 


### PR DESCRIPTION
- I removed `XCTests` module form `QuickSpec` class
- I renamed `*Tests` to `Spec` following Swift convention. 