### PR TITLE
Fix/test templates

### DIFF
--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___InteractorSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___InteractorSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___ModuleTests: QuickSpec {
+final class ___VARIABLE_moduleName___ModuleSpec: QuickSpec {
 
     override func spec() {
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___PresenterTests: QuickSpec {
+final class ___VARIABLE_moduleName___PresenterSpec: QuickSpec {
 
     override func spec() {
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___RouterTests: QuickSpec {
+final class ___VARIABLE_moduleName___RouterSpec: QuickSpec {
 
     override func spec() {
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___RouterSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 
 @testable import ___PROJECTNAME___
 
-final class ___VARIABLE_moduleName___ViewControllerTests: QuickSpec {
+final class ___VARIABLE_moduleName___ViewControllerSpec: QuickSpec {
 
     override func spec() {
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import XCTest
 
 @testable import ___PROJECTNAME___
 

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___InteractorTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___InteractorTests.swift
@@ -11,9 +11,9 @@ import XCTest
 
 final class ___VARIABLE_moduleName___InteractorTests: XCTestCase {
 
-    var interactor: ___VARIABLE_moduleName___Interactor!
+    private var interactor: ___VARIABLE_moduleName___Interactor!
     
-    var output: ___VARIABLE_moduleName___InteractorOutputMock!
+    private var output: ___VARIABLE_moduleName___InteractorOutputMock!
 
     override func setUp() {
         super.setUp()

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___ModuleTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___ModuleTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 final class ___VARIABLE_moduleName___ModuleTests: XCTestCase {
 
-    var output: ___VARIABLE_moduleName___Output!
-    var module: ___VARIABLE_moduleName___Module!
+    private var output: ___VARIABLE_moduleName___Output!
+    private var module: ___VARIABLE_moduleName___Module!
 
     override func setUp() {
         super.setUp()

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___PresenterTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___PresenterTests.swift
@@ -11,12 +11,12 @@ import XCTest
 
 final class ___VARIABLE_moduleName___PresenterTests: XCTestCase {
 
-    var presenter: ___VARIABLE_moduleName___Presenter!
+    private var presenter: ___VARIABLE_moduleName___Presenter!
 
-    var router: ___VARIABLE_moduleName___RouterInputMock!
-    var interactor: ___VARIABLE_moduleName___InteractorInputMock!
-    var view: ___VARIABLE_moduleName___ViewInputMock!
-    var output: ___VARIABLE_moduleName___OutputMock!
+    private var router: ___VARIABLE_moduleName___RouterInputMock!
+    private var interactor: ___VARIABLE_moduleName___InteractorInputMock!
+    private var view: ___VARIABLE_moduleName___ViewInputMock!
+    private var output: ___VARIABLE_moduleName___OutputMock!
 
     override func setUp() {
         super.setUp()

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___RouterTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___RouterTests.swift
@@ -11,9 +11,9 @@ import XCTest
 
 final class ___VARIABLE_moduleName___RouterTests: XCTestCase {
 
-    var router: ___VARIABLE_moduleName___Router!
+    private var router: ___VARIABLE_moduleName___Router!
 
-    var viewController: ___VARIABLE_moduleName___ViewController!
+    private var viewController: ___VARIABLE_moduleName___ViewController!
 
     override func setUp() {
         super.setUp()

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___ViewControllerTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___ViewControllerTests.swift
@@ -11,9 +11,9 @@ import XCTest
 
 final class ___VARIABLE_moduleName___ViewControllerTests: XCTestCase {
 
-    var viewController: ___VARIABLE_moduleName___ViewController!
+    private var viewController: ___VARIABLE_moduleName___ViewController!
     
-    var output: ___VARIABLE_moduleName___ViewOutputMock!
+    private var output: ___VARIABLE_moduleName___ViewOutputMock!
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
There are three changes in this pull request

- make test class variables private 
- remove XCTest import in tests using Quick and Nimble
- rename the test class names using Quick and Nimble to use Spec suffix rather than Tests 