### PR TITLE
[Compact version] Remove whitespaces in templates

### DIFF
--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___InteractorSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___InteractorSpec.swift
@@ -25,7 +25,6 @@ final class ___VARIABLE_moduleName___InteractorSpec: QuickSpec {
                 interactor = ___VARIABLE_moduleName___Interactor()
                 interactor.output = output
             }
-
         }
     }
 }

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___InteractorTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___InteractorTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class ___VARIABLE_moduleName___InteractorTests: XCTestCase {
 
     private var interactor: ___VARIABLE_moduleName___Interactor!
-    
+
     private var output: ___VARIABLE_moduleName___InteractorOutputMock!
 
     override func setUp() {


### PR DESCRIPTION
Remove whitespaces in templates because of swiftlint rules.