### PR TITLE
Omit `return` and remove white space

### DIFF
--- a/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Module.swift
+++ b/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Module.swift
@@ -22,12 +22,12 @@ final class ___VARIABLE_moduleName___Module {
     let interactor: ___VARIABLE_moduleName___Interactor
 
     var output: ___VARIABLE_moduleName___Output? {
-        get { return presenter.output }
+        get { presenter.output }
         set { presenter.output = newValue }
     }
 
     var input: ___VARIABLE_moduleName___Input {
-        return presenter
+        presenter
     }
 
     init() {

--- a/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Module.swift
+++ b/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Module.swift
@@ -26,9 +26,7 @@ final class ___VARIABLE_moduleName___Module {
         set { presenter.output = newValue }
     }
 
-    var input: ___VARIABLE_moduleName___Input {
-        presenter
-    }
+    var input: ___VARIABLE_moduleName___Input { presenter }
 
     init() {
         view = ___VARIABLE_moduleName___ViewController()

--- a/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Router.swift
+++ b/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Router.swift
@@ -17,7 +17,7 @@ final class ___VARIABLE_moduleName___Router {
     weak var view: ___VARIABLE_moduleName___ViewInput?
 
     private var viewController: UIViewController? {
-        return view as? UIViewController
+        view as? UIViewController
     }
 }
 

--- a/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___ViewController.swift
+++ b/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___ViewController.swift
@@ -34,6 +34,6 @@ final class ___VARIABLE_moduleName___ViewController: UIViewController {
 
 extension ___VARIABLE_moduleName___ViewController: ___VARIABLE_moduleName___ViewInput {
 
-    func configure() { 
+    func configure() {
     }
 }

--- a/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Module.swift
+++ b/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Module.swift
@@ -16,13 +16,11 @@ final class ___VARIABLE_moduleName___Module {
     let interactor: ___VARIABLE_moduleName___Interactor
 
     var output: ___VARIABLE_moduleName___Output? {
-        get { return presenter.output }
+        get { presenter.output }
         set { presenter.output = newValue }
     }
 
-    var input: ___VARIABLE_moduleName___Input {
-        return presenter
-    }
+    var input: ___VARIABLE_moduleName___Input { presenter }
 
     init() { 
         view = ___VARIABLE_moduleName___ViewController()

--- a/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Module.swift
+++ b/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Module.swift
@@ -22,7 +22,7 @@ final class ___VARIABLE_moduleName___Module {
 
     var input: ___VARIABLE_moduleName___Input { presenter }
 
-    init() { 
+    init() {
         view = ___VARIABLE_moduleName___ViewController()
         presenter = ___VARIABLE_moduleName___Presenter()
         router = ___VARIABLE_moduleName___Router()

--- a/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Router.swift
+++ b/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Router.swift
@@ -13,7 +13,7 @@ final class ___VARIABLE_moduleName___Router {
     weak var view: ___VARIABLE_moduleName___ViewInput?
 
     private var viewController: UIViewController? {
-        return view as? UIViewController
+        view as? UIViewController
     }
 }
 

--- a/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___ViewController.swift
+++ b/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 final class ___VARIABLE_moduleName___ViewController: UIViewController {
-    
+
     var output: ___VARIABLE_moduleName___ViewOutput?
 
     override func viewDidLoad() {

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ModuleSpec.swift
@@ -39,11 +39,11 @@ final class ___VARIABLE_moduleName___ModuleSpec: QuickSpec {
                     expect(presenter.router).to(beAKindOf(___VARIABLE_moduleName___Router.self))
                     expect(presenter.interactor).to(beAKindOf(___VARIABLE_moduleName___Interactor.self))
                     expect(presenter.output) === output
-                    expect(presenter) === module.input       
+                    expect(presenter) === module.input
                 }
 
                 it("sets interactor output with presenter") {
-                    let interactor = module.interactor 
+                    let interactor = module.interactor
                     expect(interactor.output).to(beAKindOf(___VARIABLE_moduleName___Presenter.self))
                 }
 

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
@@ -35,7 +35,7 @@ final class ___VARIABLE_moduleName___PresenterSpec: QuickSpec {
                 presenter.interactor = interactor
                 presenter.view = view
             }
-            
+
             context("when viewDidLoad is called") {
 
                 beforeEach {

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___ViewControllerTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___ViewControllerTests.swift
@@ -24,7 +24,7 @@ final class ___VARIABLE_moduleName___ViewControllerTests: XCTestCase {
         viewController.output = output
     }
 
-    func testViewDidLoad() { 
+    func testViewDidLoad() {
         viewController.viewDidLoad()
         XCTAssertTrue(output.viewDidLoadCalled)
     }


### PR DESCRIPTION
#18 

## What's Happened

As we discussed, we might need to update our template to omit return here a bit. What we are currently doing:

```swift
var input: ModuleInput { 
    return presenter
}

var output: ModuleOutput {
    get { return presenter.output }
    set { presenter.output = newValue }
}
```

And what we could do with Swift 5.1

```swift
var input: ModuleInput { presenter }

var output: ModuleOutput {
    get { presenter.output }
    set { presenter.output = newValue }
}
```


## Insight
- I remove `return`
- I remove white spacing