### PR TITLE
Inject Router and Interactor in Presenter's init

### DIFF
--- a/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Module.swift
+++ b/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Module.swift
@@ -30,15 +30,16 @@ final class ___VARIABLE_moduleName___Module {
 
     init() {
         view = ___VARIABLE_moduleName___ViewController()
-        presenter = ___VARIABLE_moduleName___Presenter()
         router = ___VARIABLE_moduleName___Router()
         interactor = ___VARIABLE_moduleName___Interactor()
+        presenter = ___VARIABLE_moduleName___Presenter(
+            router: router,
+            interactor: interactor
+        )
 
         view.output = presenter
 
         presenter.view = view
-        presenter.router = router
-        presenter.interactor = interactor
 
         interactor.output = presenter
 

--- a/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Presenter.swift
+++ b/Templates/VIPER Module Compact.xctemplate/___VARIABLE_moduleName___Presenter.swift
@@ -8,11 +8,19 @@
 
 final class ___VARIABLE_moduleName___Presenter {
 
-    weak var view: ___VARIABLE_moduleName___ViewInput?
-    var router: ___VARIABLE_moduleName___RouterInput?
-    var interactor: ___VARIABLE_moduleName___InteractorInput?
+    let router: ___VARIABLE_moduleName___RouterInput
+    let interactor: ___VARIABLE_moduleName___InteractorInput
 
+    weak var view: ___VARIABLE_moduleName___ViewInput?
     weak var output: ___VARIABLE_moduleName___Output?
+
+    init(
+        router: ___VARIABLE_moduleName___RouterInput,
+        interactor: ___VARIABLE_moduleName___InteractorInput
+    ) {
+        self.router = router
+        self.interactor = interactor
+    }
 }
 
 // MARK: - ___VARIABLE_moduleName___ViewOutput

--- a/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Module.swift
+++ b/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Module.swift
@@ -24,15 +24,16 @@ final class ___VARIABLE_moduleName___Module {
 
     init() {
         view = ___VARIABLE_moduleName___ViewController()
-        presenter = ___VARIABLE_moduleName___Presenter()
         router = ___VARIABLE_moduleName___Router()
         interactor = ___VARIABLE_moduleName___Interactor()
+        presenter = ___VARIABLE_moduleName___Presenter(
+            router: router,
+            interactor: interactor
+        )
 
         view.output = presenter
 
         presenter.view = view
-        presenter.router = router
-        presenter.interactor = interactor
 
         interactor.output = presenter
 

--- a/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Presenter.swift
+++ b/Templates/VIPER Module Default.xctemplate/___VARIABLE_moduleName___Presenter.swift
@@ -10,11 +10,19 @@ import Foundation
 
 final class ___VARIABLE_moduleName___Presenter {
 
+    let router: ___VARIABLE_moduleName___RouterInput
+    let interactor: ___VARIABLE_moduleName___InteractorInput
+    
     weak var view: ___VARIABLE_moduleName___ViewInput?
-    var router: ___VARIABLE_moduleName___RouterInput?
-    var interactor: ___VARIABLE_moduleName___InteractorInput?
-
     weak var output: ___VARIABLE_moduleName___Output?
+
+    init(
+        router: ___VARIABLE_moduleName___RouterInput,
+        interactor: ___VARIABLE_moduleName___InteractorInput
+    ) {
+        self.router = router
+        self.interactor = interactor
+    }
 }
 
 // MARK: - ___VARIABLE_moduleName___ViewOutput

--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___PresenterSpec.swift
@@ -27,12 +27,12 @@ final class ___VARIABLE_moduleName___PresenterSpec: QuickSpec {
                 router = ___VARIABLE_moduleName___RouterInputMock()
                 interactor = ___VARIABLE_moduleName___InteractorInputMock()
                 view = ___VARIABLE_moduleName___ViewInputMock()
-                presenter = ___VARIABLE_moduleName___Presenter()
+                presenter = ___VARIABLE_moduleName___Presenter(
+                    router: router,
+                    interactor: interactor
+                )
                 output = ___VARIABLE_moduleName___OutputMock()
                 presenter.output = output
-
-                presenter.router = router
-                presenter.interactor = interactor
                 presenter.view = view
             }
 

--- a/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___PresenterTests.swift
+++ b/Templates/VIPER Module Unit Tests.xctemplate/___VARIABLE_moduleName___PresenterTests.swift
@@ -20,16 +20,15 @@ final class ___VARIABLE_moduleName___PresenterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-
         router = ___VARIABLE_moduleName___RouterInputMock()
         interactor = ___VARIABLE_moduleName___InteractorInputMock()
         view = ___VARIABLE_moduleName___ViewInputMock()
-        presenter = ___VARIABLE_moduleName___Presenter()
+        presenter = ___VARIABLE_moduleName___Presenter(
+            router: router,
+            interactor: interactor
+        )
         output = ___VARIABLE_moduleName___OutputMock()
         presenter.output = output
-
-        presenter.router = router
-        presenter.interactor = interactor
         presenter.view = view
     }
 


### PR DESCRIPTION
Resolve #20

### What's Happened

Currently, we have router and interactor properties are optional in Presenter. We might not need it to be optional.

### Insights

- `Interactor` and `Router` are gonna be **strongly** captured by Presenter

