### PR TITLE
Remove brackets in test descriptions

### DIFF
--- a/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
+++ b/Templates/VIPER Module Spec.xctemplate/___VARIABLE_moduleName___ViewControllerSpec.swift
@@ -27,13 +27,13 @@ final class ___VARIABLE_moduleName___ViewControllerSpec: QuickSpec {
                 viewController.output = output
             }
 
-            context("when viewDidLoad() is called") {
+            context("when viewDidLoad is called") {
 
                 beforeEach {
                     viewController.viewDidLoad()
                 }
 
-                it("calls presenter viewDidLoad()") {
+                it("calls presenter viewDidLoad") {
                     expect(output.viewDidLoadCalled) == true
                 }
             }


### PR DESCRIPTION
### What's Happened

We are including `()` in test description only in ViewControllerSpec.
This PR removes `()` from test description.